### PR TITLE
change module description for module admin and up the version by a patch

### DIFF
--- a/modules/installed/admin/module.json
+++ b/modules/installed/admin/module.json
@@ -1,7 +1,7 @@
 {
     "name": "Admin Panel",
-    "version": "1.0.0",
-    "description": "This module allows a user to deposit and withdraw money from a bank",
+    "version": "1.0.1",
+    "description": "This module enables the administration panel",
     "author": {
         "name": "Chris Day",
         "url": "http:\/\/glscript.cdcoding.com"


### PR DESCRIPTION
I noticed that the table on the admin panel stating all modules had a wrong description for the admin panel itself

![image](https://user-images.githubusercontent.com/6582364/72605987-0e4dc000-391e-11ea-9a6b-20689052812f.png)

this is on a clean install from master
