### PR TITLE
fixing empty profileLinks hook links

### DIFF
--- a/modules/installed/profile/profile.tpl.php
+++ b/modules/installed/profile/profile.tpl.php
@@ -128,7 +128,7 @@
                 <div class="panel-body">
                     <ul class="nav nav-pills">
                         {#each profileLinks}
-                            <li><a href="{url}">{text}</a></li>
+                            {#if url}<a href="{url}">{text}</a>{/if}
                         {/each}
                     </ul>
                 </div>


### PR DESCRIPTION
some times when the hook return false it will keep a html code there this will stop that