### PR TITLE
Upgraded hash algo to use password_hash/password_verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dbconn.php
 config.php
 logs/errors/major.txt
 logs/errors/minor.txt
+.idea

--- a/class/user.php
+++ b/class/user.php
@@ -1,623 +1,659 @@
 <?php
 
-    $__userCache = array();
+$__userCache = array();
 
-    class user {
-        
-        public $id, $info, $name, $db, $loggedin = false, $nextRank, $user;
-        
-        // Pass the ID to the class
-        function __construct($id = FALSE, $name = FALSE) {
+class user
+{
 
-            global $db, $__userCache;
-            
-            if ($id && isset($__userCache[$id])) {
-                foreach(get_object_vars($__userCache[$id]) as $k => $v){
-                    $this->{$k}=$v;
-                }
-                return;
-            } 
-            
-            $this->db = $db;
-            
-            if (isset($id) || isset($name)) {
-                $this->id = $id;
-                $this->name = $name;
-                $this->getInfo();    
-                
-                if (isset($_SESSION['userID']) && $_SESSION['userID'] == $this->id) {
-                    $this->loggedin = true;
-                }
+    public $id, $info, $name, $db, $loggedin = false, $nextRank, $user;
 
-                $this->nextRank = $this->nextRank();
+    // Pass the ID to the class
+    function __construct($id = false, $name = false)
+    {
+        global $db, $__userCache;
 
+        if ($id && isset($__userCache[$id])) {
+            foreach (get_object_vars($__userCache[$id]) as $k => $v) {
+                $this->{$k} = $v;
+            }
+            return;
+        }
+
+        $this->db = $db;
+
+        if (isset($id) || isset($name)) {
+            $this->id = $id;
+            $this->name = $name;
+            $this->getInfo();
+
+            if (isset($_SESSION['userID']) && $_SESSION['userID'] == $this->id) {
+                $this->loggedin = true;
             }
 
-            $__userCache[$id] = &$this;
+            $this->nextRank = $this->nextRank();
+        }
 
-        }    
-        
-        // This function will return all the information for the user
-        public function getInfo($return = false) {
-            
-            if (!empty($this->name)) {
-                $userInfo = $this->db->prepare("
-                    SELECT 
+        $__userCache[$id] = &$this;
+    }
+
+    // This function will return all the information for the user
+    public function getInfo($return = false)
+    {
+        if (!empty($this->name)) {
+            $userInfo = $this->db->prepare("
+                    SELECT
                         *
-                    FROM 
-                        users 
-                        LEFT OUTER JOIN userStats ON (U_id = US_id) 
+                    FROM
+                        users
+                        LEFT OUTER JOIN userStats ON (U_id = US_id)
                         LEFT OUTER JOIN userRoles ON (UR_id = U_userLevel)
-                    WHERE 
+                    WHERE
                         U_name = :userName
                 ");
-                $userInfo->bindParam(':userName', $this->name);
-            } else {
-                $userInfo = $this->db->prepare("
-                    SELECT 
+            $userInfo->bindParam(':userName', $this->name);
+        } else {
+            $userInfo = $this->db->prepare("
+                    SELECT
                         *
-                    FROM 
-                        users 
-                        LEFT OUTER JOIN userStats ON (U_id = US_id) 
+                    FROM
+                        users
+                        LEFT OUTER JOIN userStats ON (U_id = US_id)
                         LEFT OUTER JOIN userRoles ON (UR_id = U_userLevel)
-                    WHERE 
+                    WHERE
                         U_id = :userID
                 ");
-                $userInfo->bindParam(':userID', $this->id);
-            }
-            
-            $userInfo->execute();
-            
-            $this->info = $userInfo->fetchObject();
+            $userInfo->bindParam(':userID', $this->id);
+        }
 
-            $access = array();
-            if (isset($this->info->U_userLevel)) {
-                $adminModules = $this->db->prepare("
+        $userInfo->execute();
+
+        $this->info = $userInfo->fetchObject();
+
+        $access = array();
+        if (isset($this->info->U_userLevel)) {
+            $adminModules = $this->db->prepare("
                     SELECT * FROM roleAccess WHERE RA_role = :id;
                 ");
-                $adminModules->bindParam(":id", $this->info->U_userLevel);
-                $adminModules->execute();
-                $adminModules = $adminModules->fetchAll(PDO::FETCH_ASSOC);
+            $adminModules->bindParam(":id", $this->info->U_userLevel);
+            $adminModules->execute();
+            $adminModules = $adminModules->fetchAll(PDO::FETCH_ASSOC);
 
-                foreach ($adminModules as $key => $value) {
-                    $access[] = $value["RA_module"];
-                }
-
+            foreach ($adminModules as $key => $value) {
+                $access[] = $value["RA_module"];
             }
-
-            $rank = $this->db->prepare("SELECT * FROM ranks WHERE R_id = :id");
-            $rank->bindParam(":id", $this->info->US_rank);
-            $rank->execute();
-            $this->rank = (object) $rank->fetch(PDO::FETCH_ASSOC);
-
-            $this->adminModules = $access;
-            
-            if (isset($user->info->U_name) || isset($user->info->U_id)) {
-                $this->id = $this->info->U_id;
-                $this->name = $this->info->U_name;
-            }
-    	    
-            $pic = $this->getProfilePicture();
-
-            if (isset($this->info->U_name)) {
-                $this->user = array(
-                    "name" => $this->info->U_name,
-                    "id" => $this->info->U_id,
-                    "userLevel" => $this->info->U_userLevel,
-                    "status" => $this->info->U_status, 
-                    "color" => $this->info->UR_color, 
-                    "gang" => $this->info->US_gang, 
-                    "profilePicture" => $pic, 
-                    "onlineStatus" => $this->getStatus(false)
-                );
-            }
-            
-            if ($return) {
-                return $this->info;
-            }
-            
-        }
-        
-        public function hasAdminAccessTo($module) {
-            return in_array($module, $this->adminModules) || in_array("*", $this->adminModules);
         }
 
-        public function encrypt($var) {
-            return hash('sha256', $var);
+        $rank = $this->db->prepare("SELECT * FROM ranks WHERE R_id = :id");
+        $rank->bindParam(":id", $this->info->US_rank);
+        $rank->execute();
+        $this->rank = (object) $rank->fetch(PDO::FETCH_ASSOC);
+
+        $this->adminModules = $access;
+
+        if (isset($user->info->U_name) || isset($user->info->U_id)) {
+            $this->id = $this->info->U_id;
+            $this->name = $this->info->U_name;
         }
-        
-        public function makeUser($username, $email, $password, $userLevel = 1, $userStatus = 1) {
-            
-            $settings = new settings();
 
-            $check = $this->db->prepare("SELECT U_id FROM users WHERE U_name = :username OR (U_email = :email AND U_status = 1)");
-            $check->bindParam(':username', $username);    
-            $check->bindParam(':email', $email);    
-            $check->execute();
-            $checkInfo = $check->fetchObject();
-            
-            if (isset($checkInfo->U_id)) {
-                
-                return 'Username or EMail are in use!';
-                
-            } else {
+        $pic = $this->getProfilePicture();
 
-                $validateUserEmail = !!$settings->loadSetting("validateUserEmail");
-                
-                if ($validateUserEmail) {
-                    $userStatus = 2;
-                }
+        if (isset($this->info->U_name)) {
+            $this->user = array(
+                "name" => $this->info->U_name,
+                "id" => $this->info->U_id,
+                "userLevel" => $this->info->U_userLevel,
+                "status" => $this->info->U_status,
+                "color" => $this->info->UR_color,
+                "gang" => $this->info->US_gang,
+                "profilePicture" => $pic,
+                "onlineStatus" => $this->getStatus(false)
+            );
+        }
 
-                $addUser = $this->db->prepare("
-                    INSERT INTO users (U_name, U_email, U_userLevel, U_status) 
+        if ($return) {
+            return $this->info;
+        }
+    }
+
+    public function hasAdminAccessTo($module)
+    {
+        return in_array($module, $this->adminModules) || in_array("*", $this->adminModules);
+    }
+
+    /**
+     * @param $var
+     * @return string
+     * @deprecated use the hash_password method instead
+     */
+    public function encrypt($var)
+    {
+        return hash('sha256', $var);
+    }
+
+    /**
+     * @param $var
+     * @return false|string|null
+     */
+    public function hash_password($var)
+    {
+        return password_hash($var, PASSWORD_DEFAULT);
+    }
+
+    /**
+     * A backward compatible way to verify user passwords
+     * @param $salt
+     * @param $password
+     * @param  null  $compareTo
+     * @return bool
+     */
+    public function verify_password($salt, $password, $compareTo = null)
+    {
+        if (hash('sha256', $salt.$password) === $compareTo) {
+            $this->set('U_password', password_hash($password, PASSWORD_DEFAULT));
+
+            return true;
+        } else {
+            if (password_verify($password, $compareTo)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function makeUser($username, $email, $password, $userLevel = 1, $userStatus = 1)
+    {
+        $settings = new settings();
+
+        $check = $this->db->prepare("SELECT U_id FROM users WHERE U_name = :username OR (U_email = :email AND U_status = 1)");
+        $check->bindParam(':username', $username);
+        $check->bindParam(':email', $email);
+        $check->execute();
+        $checkInfo = $check->fetchObject();
+
+        if (isset($checkInfo->U_id)) {
+            return 'Username or EMail are in use!';
+        } else {
+            $validateUserEmail = !!$settings->loadSetting("validateUserEmail");
+
+            if ($validateUserEmail) {
+                $userStatus = 2;
+            }
+
+            $addUser = $this->db->prepare("
+                    INSERT INTO users (U_name, U_email, U_userLevel, U_status)
                     VALUES (:username, :email, :userLevel, :userStatus)
                 ");
-                $addUser->bindParam(':username', $username);
-                $addUser->bindParam(':email', $email);
-                $addUser->bindParam(':userLevel', $userLevel);
-                $addUser->bindParam(':userStatus', $userStatus);
-                $addUser->execute();
+            $addUser->bindParam(':username', $username);
+            $addUser->bindParam(':email', $email);
+            $addUser->bindParam(':userLevel', $userLevel);
+            $addUser->bindParam(':userStatus', $userStatus);
+            $addUser->execute();
 
-                $id = $this->db->lastInsertId();
-                $this->id = $id;
-                
-                $encryptedPassword = $this->encrypt($id . $password);
+            $id = $this->db->lastInsertId();
+            $this->id = $id;
 
-                $addUserPassword = $this->db->prepare("
+            $hashedPassword = $this->hash_password($password);
+
+            $addUserPassword = $this->db->prepare("
                     UPDATE users SET U_password = :password WHERE U_id = :id
                 ");
-                $addUserPassword->bindParam(':id', $id);
-                $addUserPassword->bindParam(':password', $encryptedPassword);
-                $addUserPassword->execute();
+            $addUserPassword->bindParam(':id', $id);
+            $addUserPassword->bindParam(':password', $hashedPassword);
+            $addUserPassword->execute();
 
-                $this->db->query("INSERT INTO userStats (US_id) VALUES (" . $id . ")");
+            $this->db->query("INSERT INTO userStats (US_id) VALUES (".$id.")");
 
-                $this->updateTimer("signup", time());
+            $this->updateTimer("signup", time());
 
-                if ($validateUserEmail) {
-                    $this->sendActivationCode($email, $id, $username);
-                }
-
-                $hook = new Hook("newUser");
-                $hook->run($id);
-                
-                return $id;
-                
-            }
-            
-        }
-        
-        public function sendActivationCode($email, $id, $username) {
-            $settings = new settings();
-            $from =  $settings->loadSetting('from_email');
-            $headers = array();
-            if ($from) {
-                $headers['From'] = $from;
+            if ($validateUserEmail) {
+                $this->sendActivationCode($email, $id, $username);
             }
 
-            $gameName = $settings->loadSetting("game_name");
-            $activationCode = $this->activationCode($id, $username);
-            $subject = $gameName . " - Registration";
-            $body = "$username your activation code for $gameName is $activationCode, after you have logged in please enter this when prompted.";
-            mail($email, $subject, $body, $headers);
+            $hook = new Hook("newUser");
+            $hook->run($id);
+
+            return $id;
+        }
+    }
+
+    public function sendActivationCode($email, $id, $username)
+    {
+        $settings = new settings();
+        $from = $settings->loadSetting('from_email');
+        $headers = array();
+        if ($from) {
+            $headers['From'] = $from;
         }
 
-        public function activationCode($id, $username) {
-            return substr($this->encrypt($id . $username), 0, 6);
-        }
+        $gameName = $settings->loadSetting("game_name");
+        $activationCode = $this->activationCode($id, $username);
+        $subject = $gameName." - Registration";
+        $body = "$username your activation code for $gameName is $activationCode, after you have logged in please enter this when prompted.";
+        mail($email, $subject, $body, $headers);
+    }
 
-        public function getNotificationCount($id, $type = 'all') {
-                
-            global $page;
-            
-            if ($type == 'all') {
-                
-                $notifications = $this->db->prepare("SELECT COUNT(M_id)+(SELECT COUNT(N_id) FROM notifications WHERE N_uid = :user1 AND N_read = 0) as count FROM mail WHERE M_uid = :user2 AND M_read = 0");
-                $notifications->bindParam(':user1', $id);
-                $notifications->bindParam(':user2', $id);
-                $notifications->execute();
-                $result = $notifications->fetchObject();
-                
-                $page->addToTemplate('all_notifications', $result->count); 
-                return $result->count;
-                
-            } else if ($type == 'mail') {
-                
+    public function activationCode($id, $username)
+    {
+        return substr($this->encrypt($id.$username), 0, 6);
+    }
+
+    public function getNotificationCount($id, $type = 'all')
+    {
+        global $page;
+
+        if ($type == 'all') {
+            $notifications = $this->db->prepare("SELECT COUNT(M_id)+(SELECT COUNT(N_id) FROM notifications WHERE N_uid = :user1 AND N_read = 0) as count FROM mail WHERE M_uid = :user2 AND M_read = 0");
+            $notifications->bindParam(':user1', $id);
+            $notifications->bindParam(':user2', $id);
+            $notifications->execute();
+            $result = $notifications->fetchObject();
+
+            $page->addToTemplate('all_notifications', $result->count);
+            return $result->count;
+        } else {
+            if ($type == 'mail') {
                 $notifications = $this->db->prepare("SELECT COUNT(M_id) as count FROM mail WHERE M_uid = :user1 AND M_read = 0");
                 $notifications->bindParam(':user1', $id);
                 $notifications->execute();
                 $result = $notifications->fetchObject();
-                
+
                 $page->addToTemplate('mail', $result->count);
-                
+
                 return $result->count;
-                
-            } else if ($type == 'notifications') {
-                
-                $notifications = $this->db->prepare("SELECT COUNT(N_id) as count FROM notifications WHERE N_uid = :user1 AND N_read = 0");
-                $notifications->bindParam(':user1', $id);
-                $notifications->execute();
-                $result = $notifications->fetchObject();
-                
-                $page->addToTemplate('notificationCount', $result->count);
-                return $result->count;
-                
-            }
-
-            return 0;
-        }
-
-        public function getProfilePicture() {
-
-            if (isset($this->info->profilePictureChecked)) return $this->info->US_pic;
-
-            $image = @new FastImage($this->info->US_pic);
-            $size = $image->getSize();
-
-            if (!isset($size[0])) {
-                $this->info->US_pic = "themes/" . _setting("theme") . "/images/default-profile-picture.png";
-            }
-
-            $this->info->profilePictureChecked = true;
-
-            return $this->info->US_pic;
-
-        }
-        
-        public function bindVarsToTemplate() {
-            
-            global $page;
-            
-            $this->getNotificationCount($this->info->U_id, 'mail'); 
-            $this->getNotificationCount($this->info->U_id, 'notifications'); 
-
-            
-            $pic = $this->getProfilePicture();
-
-            $maxHealth = $this->rank->R_health;
-
-            $health = ($maxHealth - $this->info->US_health) / $maxHealth * 100; 
-            if ($health < 0) $health = 0;
-
-            $page->addToTemplate('pic', $pic);
-            $page->addToTemplate('money', '$'.number_format($this->info->US_money));
-            $page->addToTemplate('bullets', number_format($this->info->US_bullets));
-            $page->addToTemplate('backfire', number_format($this->info->US_backfire));
-            $page->addToTemplate('points', $this->info->US_points);
-            $page->addToTemplate('health', number_format($health, 2));
-            $page->addToTemplate('location', $this->getLocation());
-            $page->addToTemplate('locationID', $this->info->US_location);
-            $page->addToTemplate('username', $this->info->U_name);
-            $page->addToTemplate('userStatus', $this->info->U_status);
-            $page->addToTemplate('user', $this->user);
-
-            $page->addToTemplate('isAdmin', count($this->adminModules) != 0);
-            
-            $hook = new Hook("userInformation");
-
-            $hook->run($this);
-            
-            $rank = $this->getRank();
-            $gang = $this->getGang();
-            $weapon = $this->getWeapon();
-            $armor = $this->getArmor();
-
-            
-            if (isset($this->nextRank->R_exp)) {
-                if ($rank->R_id == $this->nextRank->R_id) {
-                    $this->nextRank = $this->nextRank();
-                }
-                $expIntoNextRank =  $this->info->US_exp - $rank->R_exp;
-                $expNeededForNextRank = $this->nextRank->R_exp - $rank->R_exp;
-                $expperc = round($expIntoNextRank / $expNeededForNextRank * 100, 2);
-                $this->info->maxRank = false;
             } else {
-                $this->info->maxRank = true;
-                $thisRank = $this->getRank($this->info->U_id);
-                $expperc = round($this->info->US_exp / $thisRank->R_exp * 100, 2) % 100;
+                if ($type == 'notifications') {
+                    $notifications = $this->db->prepare("SELECT COUNT(N_id) as count FROM notifications WHERE N_uid = :user1 AND N_read = 0");
+                    $notifications->bindParam(':user1', $id);
+                    $notifications->execute();
+                    $result = $notifications->fetchObject();
+
+                    $page->addToTemplate('notificationCount', $result->count);
+                    return $result->count;
+                }
             }
-            
-            $page->addToTemplate('maxRank', $this->info->maxRank);
-            $page->addToTemplate('rank', $rank->R_name);
-            @$page->addToTemplate('exp_perc', $expperc);
-            $page->addToTemplate('gang', $gang);
-            $page->addToTemplate('weapon', $weapon->I_name);
-            $page->addToTemplate('armor', $armor->I_name);
-            $page->addToTemplate('nextRank', $this->nextRank->R_name);
-            
         }
-        
-        public function getMoneyRank() {
-            $query = $this->db->prepare("
+
+        return 0;
+    }
+
+    public function getProfilePicture()
+    {
+        if (isset($this->info->profilePictureChecked)) {
+            return $this->info->US_pic;
+        }
+
+        $image = @new FastImage($this->info->US_pic);
+        $size = $image->getSize();
+
+        if (!isset($size[0])) {
+            $this->info->US_pic = "themes/"._setting("theme")."/images/default-profile-picture.png";
+        }
+
+        $this->info->profilePictureChecked = true;
+
+        return $this->info->US_pic;
+    }
+
+    public function bindVarsToTemplate()
+    {
+        global $page;
+
+        $this->getNotificationCount($this->info->U_id, 'mail');
+        $this->getNotificationCount($this->info->U_id, 'notifications');
+
+
+        $pic = $this->getProfilePicture();
+
+        $maxHealth = $this->rank->R_health;
+
+        $health = ($maxHealth - $this->info->US_health) / $maxHealth * 100;
+        if ($health < 0) {
+            $health = 0;
+        }
+
+        $page->addToTemplate('pic', $pic);
+        $page->addToTemplate('money', '$'.number_format($this->info->US_money));
+        $page->addToTemplate('bullets', number_format($this->info->US_bullets));
+        $page->addToTemplate('backfire', number_format($this->info->US_backfire));
+        $page->addToTemplate('points', $this->info->US_points);
+        $page->addToTemplate('health', number_format($health, 2));
+        $page->addToTemplate('location', $this->getLocation());
+        $page->addToTemplate('locationID', $this->info->US_location);
+        $page->addToTemplate('username', $this->info->U_name);
+        $page->addToTemplate('userStatus', $this->info->U_status);
+        $page->addToTemplate('user', $this->user);
+
+        $page->addToTemplate('isAdmin', count($this->adminModules) != 0);
+
+        $hook = new Hook("userInformation");
+
+        $hook->run($this);
+
+        $rank = $this->getRank();
+        $gang = $this->getGang();
+        $weapon = $this->getWeapon();
+        $armor = $this->getArmor();
+
+
+        if (isset($this->nextRank->R_exp)) {
+            if ($rank->R_id == $this->nextRank->R_id) {
+                $this->nextRank = $this->nextRank();
+            }
+            $expIntoNextRank = $this->info->US_exp - $rank->R_exp;
+            $expNeededForNextRank = $this->nextRank->R_exp - $rank->R_exp;
+            $expperc = round($expIntoNextRank / $expNeededForNextRank * 100, 2);
+            $this->info->maxRank = false;
+        } else {
+            $this->info->maxRank = true;
+            $thisRank = $this->getRank($this->info->U_id);
+            $expperc = round($this->info->US_exp / $thisRank->R_exp * 100, 2) % 100;
+        }
+
+        $page->addToTemplate('maxRank', $this->info->maxRank);
+        $page->addToTemplate('rank', $rank->R_name);
+        @$page->addToTemplate('exp_perc', $expperc);
+        $page->addToTemplate('gang', $gang);
+        $page->addToTemplate('weapon', $weapon->I_name);
+        $page->addToTemplate('armor', $armor->I_name);
+        $page->addToTemplate('nextRank', $this->nextRank->R_name);
+    }
+
+    public function getMoneyRank()
+    {
+        $query = $this->db->prepare("
                 SELECT * FROM moneyRanks WHERE MR_money <= :money ORDER BY MR_money DESC LIMIT 0, 1
             ");
-            $cash = $this->info->US_money + $this->info->US_bank;
-            $query->bindParam(":money", $cash);
-            $query->execute();
-            $result = $query->fetchObject();
-            return $result;
-        }
-        
-        public function getRank() {
-            
-            $query = $this->db->prepare("SELECT * FROM ranks WHERE R_id = :rank");
-            $query->bindParam(":rank", $this->info->US_rank);
-            $query->execute();
-            $result = $query->fetchObject();
-            
-            return $result;
-            
-        }
-        
-        public function getGang() {
-            
-            if (!$this->info->US_gang) {
-                return array(
-                    "id" => 0, 
-                    "name" => "None"
-                );
-            }
+        $cash = $this->info->US_money + $this->info->US_bank;
+        $query->bindParam(":money", $cash);
+        $query->execute();
+        $result = $query->fetchObject();
+        return $result;
+    }
 
+    public function getRank()
+    {
+        $query = $this->db->prepare("SELECT * FROM ranks WHERE R_id = :rank");
+        $query->bindParam(":rank", $this->info->US_rank);
+        $query->execute();
+        $result = $query->fetchObject();
 
-            $query = $this->db->prepare("SELECT G_id as 'id', G_name as 'name' FROM gangs WHERE G_id = :gang");
-            $query->bindParam(":gang", $this->info->US_gang);
-            $query->execute();
-            $result = $query->fetch(PDO::FETCH_ASSOC);
-            
-            return $result;
-            
-        }
-        
-        public function getWeapon() {
-            
-            $query = $this->db->prepare("SELECT * FROM items WHERE I_id = :weapon");
-            $query->bindParam(":weapon", $this->info->US_weapon);
-            $query->execute();
-            $result = $query->fetchObject();
-            
-            if (!$result) {
-                return (object) array("I_name" => "None");
-            } 
+        return $result;
+    }
 
-            return $result;
-            
-        }
-        
-        public function getArmor() {
-            
-            $query = $this->db->prepare("SELECT * FROM items WHERE I_id = :armor");
-            $query->bindParam(":armor", $this->info->US_armor);
-            $query->execute();
-            $result = $query->fetchObject();
-            
-            if (!$result) {
-                return (object) array("I_name" => "None");
-            } 
-
-            return $result;
-            
-        }
-        
-        public function set($stat, $value) {
-
-            if ($stat[1] == "_") {
-                $table = "users";
-                $id = "U_id";
-            } else {
-                $table = "userStats";
-                $id = "US_id";
-            }
-
-            $query = $this->db->prepare("UPDATE $table SET $stat = :value WHERE $id = :id");
-            $query->bindParam(":id", $this->info->US_id);
-            $query->bindParam(":value", $value);
-            $query->execute();
-
-            $this->info->$stat = $value;
-
+    public function getGang()
+    {
+        if (!$this->info->US_gang) {
+            return array(
+                "id" => 0,
+                "name" => "None"
+            );
         }
 
-        public function add($value, $stat) {
-            $this->set($stat, $this->info->$stat + $value);
+
+        $query = $this->db->prepare("SELECT G_id as 'id', G_name as 'name' FROM gangs WHERE G_id = :gang");
+        $query->bindParam(":gang", $this->info->US_gang);
+        $query->execute();
+        $result = $query->fetch(PDO::FETCH_ASSOC);
+
+        return $result;
+    }
+
+    public function getWeapon()
+    {
+        $query = $this->db->prepare("SELECT * FROM items WHERE I_id = :weapon");
+        $query->bindParam(":weapon", $this->info->US_weapon);
+        $query->execute();
+        $result = $query->fetchObject();
+
+        if (!$result) {
+            return (object) array("I_name" => "None");
         }
 
-        public function subtract($value, $stat) {
-            $this->set($stat, $this->info->$stat + $value);
+        return $result;
+    }
+
+    public function getArmor()
+    {
+        $query = $this->db->prepare("SELECT * FROM items WHERE I_id = :armor");
+        $query->bindParam(":armor", $this->info->US_armor);
+        $query->execute();
+        $result = $query->fetchObject();
+
+        if (!$result) {
+            return (object) array("I_name" => "None");
         }
 
-        public $counter = 0;
-        
-        public function nextRank() {
+        return $result;
+    }
 
-            $rank = $this->getRank();
-
-            $nextRank = $this->db->prepare("SELECT * FROM ranks WHERE R_exp > :oldExp ORDER BY R_exp LIMIT 0, 1");
-            $nextRank->bindParam(":oldExp", $rank->R_exp);
-            $nextRank->execute();
-            $newRank = (object) $nextRank->fetch(PDO::FETCH_ASSOC);
-
-            return $newRank;
+    public function set($stat, $value)
+    {
+        if ($stat[1] == "_") {
+            $table = "users";
+            $id = "U_id";
+        } else {
+            $table = "userStats";
+            $id = "US_id";
         }
 
-        public function checkRank() {
-            
-            global $page;
+        $query = $this->db->prepare("UPDATE $table SET $stat = :value WHERE $id = :id");
+        $query->bindParam(":id", $this->info->US_id);
+        $query->bindParam(":value", $value);
+        $query->execute();
 
-            $newRank = $this->nextRank();
+        $this->info->$stat = $value;
+    }
 
-            if (isset($newRank->R_exp) && $newRank->R_exp <= $this->info->US_exp) {
+    public function add($value, $stat)
+    {
+        $this->set($stat, $this->info->$stat + $value);
+    }
 
-                if ($newRank->R_limit) {
-                    $usersInRank = $this->db->select("
-                        SELECT COUNT(US_id) as 'count' 
-                        FROM userStats 
+    public function subtract($value, $stat)
+    {
+        $this->set($stat, $this->info->$stat + $value);
+    }
+
+    public $counter = 0;
+
+    public function nextRank()
+    {
+        $rank = $this->getRank();
+
+        $nextRank = $this->db->prepare("SELECT * FROM ranks WHERE R_exp > :oldExp ORDER BY R_exp LIMIT 0, 1");
+        $nextRank->bindParam(":oldExp", $rank->R_exp);
+        $nextRank->execute();
+        $newRank = (object) $nextRank->fetch(PDO::FETCH_ASSOC);
+
+        return $newRank;
+    }
+
+    public function checkRank()
+    {
+        global $page;
+
+        $newRank = $this->nextRank();
+
+        if (isset($newRank->R_exp) && $newRank->R_exp <= $this->info->US_exp) {
+            if ($newRank->R_limit) {
+                $usersInRank = $this->db->select("
+                        SELECT COUNT(US_id) as 'count'
+                        FROM userStats
                         INNER JOIN users ON (U_id = US_id)
                         WHERE US_rank = :rank AND U_status = 1
                     ", array(
-                        ":rank" => $newRank->R_id
-                    ));
-                    if ($usersInRank["count"] >= $newRank->R_limit) return $newRank;
-                }
-
-                $this->counter++;
-
-                $this->set("US_rank", $newRank->R_id);
-                $this->set("US_bullets", $this->info->US_bullets + $newRank->R_bulletReward);
-                $this->set("US_money", $this->info->US_money + $newRank->R_cashReward);
-
-                $rewards = array();
-
-                if ($newRank->R_bulletReward) $rewards[] = array( 
-                    "name" => "Bullets",
-                    "value" => number_format($newRank->R_bulletReward) 
-                );
-                
-                if ($newRank->R_cashReward) $rewards[] = array( 
-                    "name" => "Cash" ,
-                    "value" => "$" . number_format($newRank->R_cashReward) 
-                );
-
-                $text = $page->buildElement("levelUpNotification", array(
-                    "rankName" => $newRank->R_name,
-                    "rewards" => $rewards
+                    ":rank" => $newRank->R_id
                 ));
-
-                $actionHook = new hook("userAction");
-                $action = array(
-                    "user" => $this->info->U_id, 
-                    "module" => "rank", 
-                    "id" => 0, 
-                    "success" => true, 
-                    "reward" => $newRank->R_id, 
-                    "gt" => true
-                );
-                $actionHook->run($action);
-
-                $hook = new Hook("rankUp");
-                $info = array(
-                    "user" => $this->info->U_id,
-                    "rank" => $newRank->R_id
-                );
-                $hook->run($info);
-
-                $this->newNotification($text);
-                return $this->checkRank();
-            } else {
-                return $newRank;
+                if ($usersInRank["count"] >= $newRank->R_limit) {
+                    return $newRank;
+                }
             }
 
+            $this->counter++;
+
+            $this->set("US_rank", $newRank->R_id);
+            $this->set("US_bullets", $this->info->US_bullets + $newRank->R_bulletReward);
+            $this->set("US_money", $this->info->US_money + $newRank->R_cashReward);
+
+            $rewards = array();
+
+            if ($newRank->R_bulletReward) {
+                $rewards[] = array(
+                    "name" => "Bullets",
+                    "value" => number_format($newRank->R_bulletReward)
+                );
+            }
+
+            if ($newRank->R_cashReward) {
+                $rewards[] = array(
+                    "name" => "Cash",
+                    "value" => "$".number_format($newRank->R_cashReward)
+                );
+            }
+
+            $text = $page->buildElement("levelUpNotification", array(
+                "rankName" => $newRank->R_name,
+                "rewards" => $rewards
+            ));
+
+            $actionHook = new hook("userAction");
+            $action = array(
+                "user" => $this->info->U_id,
+                "module" => "rank",
+                "id" => 0,
+                "success" => true,
+                "reward" => $newRank->R_id,
+                "gt" => true
+            );
+            $actionHook->run($action);
+
+            $hook = new Hook("rankUp");
+            $info = array(
+                "user" => $this->info->U_id,
+                "rank" => $newRank->R_id
+            );
+            $hook->run($info);
+
+            $this->newNotification($text);
+            return $this->checkRank();
+        } else {
+            return $newRank;
         }
-        
-        public function newNotification($text) {
-            $notification = $this->db->prepare("
+    }
+
+    public function newNotification($text)
+    {
+        $notification = $this->db->prepare("
                 INSERT INTO notifications (
                     N_uid, N_text, N_read, N_time
                 ) VALUES (
                     :id, :text, 0, UNIX_TIMESTAMP()
                 );
             ");
-            $notification->bindParam(":id", $this->info->U_id);
-            $notification->bindParam(":text", $text);
-            $notification->execute();
+        $notification->bindParam(":id", $this->info->U_id);
+        $notification->bindParam(":text", $text);
+        $notification->execute();
+    }
+
+    public function getLocation()
+    {
+        $location = $this->db->prepare("SELECT L_name FROM locations WHERE L_id = :location");
+        $location->bindParam(':location', $this->info->US_location);
+        $location->execute();
+
+        $return = $location->fetch(PDO::FETCH_ASSOC);
+
+        return $return['L_name'];
+    }
+
+    public function checkTimer($timer)
+    {
+        $time = $this->getTimer($timer);
+        return (time() > $time);
+    }
+
+    public function getTimer($timer, $make = true)
+    {
+        $userID = $this->id;
+
+        if (!$userID) {
+            $userID = $this->info->U_id;
         }
 
-        public function getLocation() {
-            
-            $location = $this->db->prepare("SELECT L_name FROM locations WHERE L_id = :location");
-            $location->bindParam(':location', $this->info->US_location);
-            $location->execute();
-            
-            $return = $location->fetch(PDO::FETCH_ASSOC);
-            
-            return $return['L_name'];
-        }
-        
-        public function checkTimer($timer) {
-            $time = $this->getTimer($timer);
-            return (time() > $time);
-        }
-        
-        public function getTimer($timer, $make = true) {
-        
-            $userID = $this->id;
-            
-            if (!$userID) $userID = $this->info->U_id;
-
-            $select = $this->db->prepare("
+        $select = $this->db->prepare("
                 SELECT * FROM userTimers WHERE UT_desc = :desc AND UT_user = :user;
             ");
-            $select->bindParam(':user', $userID);
-            $select->bindParam(':desc', $timer);
-            $select->execute();
-            
-            $array = $select->fetch(PDO::FETCH_ASSOC);
-            
-            // If the array is empty we make the user timer, this way the developer does not have to make any changes to the database to make a new timer.
-            if (empty($array['UT_time'])) {
-                if ($make) {
-                    $time = time()-1;
-                    $insert = $this->db->prepare("INSERT INTO userTimers (UT_user, UT_desc, UT_time) VALUES (:user, :desc, :time)");
-                    $insert->bindParam(':user', $userID);
-                    $insert->bindParam(':desc', $timer);
-                    $insert->bindParam(':time', $time);
-                    $insert->execute();
-                    return $time;
-                } else {
-                    return 0;
-                }
-                
+        $select->bindParam(':user', $userID);
+        $select->bindParam(':desc', $timer);
+        $select->execute();
+
+        $array = $select->fetch(PDO::FETCH_ASSOC);
+
+        // If the array is empty we make the user timer, this way the developer does not have to make any changes to the database to make a new timer.
+        if (empty($array['UT_time'])) {
+            if ($make) {
+                $time = time() - 1;
+                $insert = $this->db->prepare("INSERT INTO userTimers (UT_user, UT_desc, UT_time) VALUES (:user, :desc, :time)");
+                $insert->bindParam(':user', $userID);
+                $insert->bindParam(':desc', $timer);
+                $insert->bindParam(':time', $time);
+                $insert->execute();
+                return $time;
             } else {
-                
-                return $array['UT_time'];
-                
+                return 0;
             }
-            
+        } else {
+            return $array['UT_time'];
         }
-        
-        public function updateTimer($timer, $time, $add = false) {
-        
-            $user = $this->id;
-            
-            if (!$user) $user = $this->info->U_id;
-            
-            // Check that the timer exists, if it dosent this function will automaticly make it.
-            // We do this so the user does not have to make any database changes to make a module.
-            $oldTimer = $this->getTimer($timer);
+    }
 
-            if ($add) {
-                $time = time() + $time;
-            }
-            
-            $update = $this->db->prepare("UPDATE userTimers SET UT_time = :time WHERE UT_user = :user AND UT_desc = :desc");
-            $update->bindParam(':time', $time);
-            $update->bindParam(':user', $user);
-            $update->bindParam(':desc', $timer);
-            $update->execute();
+    public function updateTimer($timer, $time, $add = false)
+    {
+        $user = $this->id;
 
-            $hook = new Hook("userTimerUpdated");
-            $data = array(
-                "timer" => $timer, 
-                "time" => $time, 
-                "user" => $user
-            );
-            $hook->run($data);
-            
+        if (!$user) {
+            $user = $this->info->U_id;
         }
 
-        public function getStatus($returnElement = true, $time = false) {
-            
-            if (!$time) {
-                $time =(time() - $this->getTimer("laston"));
+        // Check that the timer exists, if it dosent this function will automaticly make it.
+        // We do this so the user does not have to make any database changes to make a module.
+        $oldTimer = $this->getTimer($timer);
+
+        if ($add) {
+            $time = time() + $time;
+        }
+
+        $update = $this->db->prepare("UPDATE userTimers SET UT_time = :time WHERE UT_user = :user AND UT_desc = :desc");
+        $update->bindParam(':time', $time);
+        $update->bindParam(':user', $user);
+        $update->bindParam(':desc', $timer);
+        $update->execute();
+
+        $hook = new Hook("userTimerUpdated");
+        $data = array(
+            "timer" => $timer,
+            "time" => $time,
+            "user" => $user
+        );
+        $hook->run($data);
+    }
+
+    public function getStatus($returnElement = true, $time = false)
+    {
+        if (!$time) {
+            $time = (time() - $this->getTimer("laston"));
+        }
+        global $page;
+
+        if ($time > 300 && $time <= 900) {
+            if ($returnElement) {
+                return $page->buildElement("AFK", array());
+            } else {
+                return 1;
             }
-            global $page;
-            
-            if ($time > 300 && $time <= 900) {
-                if ($returnElement) {
-                    return $page->buildElement("AFK", array());
-                } else {
-                    return 1;
-                }
-            } else if ($time > 900) {
+        } else {
+            if ($time > 900) {
                 if ($returnElement) {
                     return $page->buildElement("offline", array());
                 } else {
@@ -630,15 +666,14 @@
                     return 2;
                 }
             }
-            
         }
-        
-        public function logout() {
-        
-            session_destroy();
-            
-        }
-        
     }
-    
+
+    public function logout()
+    {
+        session_destroy();
+    }
+
+}
+
 ?>

--- a/modules/installed/forgotPassword/forgotPassword.inc.php
+++ b/modules/installed/forgotPassword/forgotPassword.inc.php
@@ -1,7 +1,7 @@
 <?php
 
     class forgotPassword extends module {
-        
+
         public $regError = "";
 
         public $allowedMethods = array(
@@ -11,19 +11,19 @@
             'password'=>array('type'=>'post'),
             'cpassword'=>array('type'=>'post')
         );
-        
+
         public function constructModule() {
-            
+
             global $regError;
 
             $settings = new settings();
             $this->page->addToTemplate("loginSuffix", $settings->loadSetting("loginSuffix"));
             $this->page->addToTemplate("loginPostfix", $settings->loadSetting("loginPostfix"));
-            
+
             $this->html .= $this->page->buildElement('resetPasswordEmail');
-            
+
         }
-        
+
         public function method_reset() {
 
             $this->error("A password reset email has been sent to you!", "success");
@@ -44,7 +44,7 @@
         }
 
         public function method_resetPassword() {
-            
+
 
             if (!isset($this->methodData->id)) {
                 return $this->error("Invalid reset link");
@@ -69,7 +69,7 @@
                 if ($this->methodData->password != $this->methodData->cpassword) {
                     $this->error("Passwords do not match");
                 } else {
-                    $new = $user->encrypt($user->info->U_id . $this->methodData->password);
+                    $new = $user->hash_password($this->methodData->password);
                     $user->set("U_password", $new);
                     $this->error("Your password has been reset, you can now login!", "success");
                 }
@@ -85,9 +85,9 @@
                 "id" => $this->methodData->id,
                 "auth" => $this->methodData->auth
             ));
-            
+
         }
-        
+
     }
 
 ?>

--- a/modules/installed/login/login.inc.php
+++ b/modules/installed/login/login.inc.php
@@ -1,13 +1,13 @@
 <?php
 
     class login extends module {
-        
+
         public $allowedMethods = array(
-            'logout'=>array('type'=>'get'), 
-            'email'=>array('type'=>'post'), 
+            'logout'=>array('type'=>'get'),
+            'email'=>array('type'=>'post'),
             'password'=>array('type'=>'post')
         );
-        
+
         public function constructModule() {
 
             $settings = new settings();
@@ -16,15 +16,15 @@
 
             $this->html .= $this->page->buildElement('loginForm');
 
-            
+
         }
-        
+
         public function method_logout() {
             $this->error('You have been logged out!');
         }
-        
+
         public function method_login() {
-                
+
             $userExists = @$this->db->prepare("
                 SELECT * FROM users WHERE U_email = :email ORDER BY U_id DESC LIMIT 0, 1
             ");
@@ -32,18 +32,19 @@
             $userExists->execute();
             $userExists = $userExists->fetch(PDO::FETCH_ASSOC);
 
-            
+
             if (isset($userExists["U_id"])) {
                 $user = new User($userExists["U_id"]);
-                if ($user->info->U_password == $user->encrypt($user->info->U_id . $this->methodData->password)) {
+
+                if ($user->verify_password($user->info->U_id, $this->methodData->password, $user->info->U_password)) {
                     $_SESSION['userID'] = $user->info->U_id;
-     
+
                     $actionHook = new hook("userAction");
                     $action = array(
-                        "user" => $this->user->id, 
-                        "module" => "login", 
-                        "id" => $this->user->id, 
-                        "success" => true, 
+                        "user" => $this->user->id,
+                        "module" => "login",
+                        "id" => $this->user->id,
+                        "success" => true,
                         "reward" => 0
                     );
                     $actionHook->run($action);
@@ -53,11 +54,11 @@
                     $this->error('You have entered a wrong email/password!');
                 }
             } else {
-                $this->error('You have entered a wrong email/password!');    
+                $this->error('You have entered a wrong email/password!');
             }
-            
+
         }
-        
+
     }
 
 ?>


### PR DESCRIPTION
Added a backward compatible way to update the hash algo from `sha256` to use the preferred `password_hash` and `password_verify` methods.

- Introduced two new methods `hash_password($var)` and `verify_password($salt, $password, $compareTo = null)`
- Removed the user ID salt as `password_hash` handles salt generation

I've tested login and register with both passwords using the old algo and the new one but can't test forgot password locally, though, theoretically it should work as login and register do.